### PR TITLE
prevent widening of type if >1 union-type is string with ElementAttributes

### DIFF
--- a/src/LumeElement.ts
+++ b/src/LumeElement.ts
@@ -5,8 +5,8 @@ import {render} from 'solid-js/web'
 // element preupgrade value.
 import {Effectful, __isPropSetAtLeastOnce} from 'classy-solid'
 
+import type {DashCasedProps, IsString} from './_utils'
 import type {AttributeHandler} from './attribute'
-import type {DashCasedProps} from './_utils'
 
 // TODO `templateMode: 'append' | 'replace'`, which allows a subclass to specify
 // if template content replaces the content of `root`, or is appended to `root`.
@@ -459,5 +459,5 @@ export type ElementAttributes<
 	Omit<JSX.HTMLAttributes<ElementType>, SelectedProperties | keyof AdditionalProperties>
 
 type WithStringValues<Type extends object> = {
-	[Property in keyof Type]: NonNullable<Type[Property]> extends string ? Type[Property] : Type[Property] | string
+	[Property in keyof Type]: IsString<Type[Property]> extends false ? Type[Property] | string : Type[Property]
 }

--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -161,3 +161,11 @@ export type DashCasedProps<T> = {
 //    fooBar: string;
 //    foo: number;
 // }
+
+/**
+ * Returns
+ * - `true` if all of union-types are `string`
+ *  - `false` if none of union-types are `string`
+ *  - `boolean` if >1 of union-types are `string`
+ */
+export type IsString<U> = U extends string ? true : false


### PR DESCRIPTION
hi joe 👋

I was facing the following problem:
`@attribute() prop: 'big' | Promise<'mistqke'>` would generate `string | Promise<'mistqke'>` type with ElementAttributes. this was due to NonNullable<Type[Property]> extends string resolving to 'boolean' instead of 'true'

solution:
- I made a small utility type: `IsString`
- `IsString` returns 
    - `true` if all of the union-types are `string` 
    - `false` if none of the union-types are `string` 
    - `boolean` if >1 of the union-types are `string``string`
- replaced 
    - `NonNullable<Type[Property]> extends true ? Type[Property] : Type[Property]  | string`
- with 
    - `IsString<Type[Property]> extends false ? Type[Property]  | string :  Type[Property]`

this is a better solution then my earlier proposal of `NonNullable<Type[Property]>`, as it takes care of all unions that include a string, not only the ones that have undefined included.